### PR TITLE
Add test for high concurrency.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,30 +1,10 @@
 import { defer } from 'promise-callbacks';
+import { extractFrom } from './utils';
 
 // Sentinel value because undefined and null might be valid values.
 const SENTINEL = Object.create(null);
 
 const hasOwn = Object.prototype.hasOwnProperty;
-
-/**
- * Extract num entries from map and return them in a new Map.
- *
- * @param {Map} map The source map.
- * @param {number} num The number of entries to extract.
- * @return {[Map, Map]} The first value is a new Map containing the remaining entries from the
- *   source map, and the second value is a new Map containing the extracted entries.
- */
-function extractFrom(map, num) {
-  if (!(num < map.size)) {
-    return [new Map(), new Map(map)];
-  }
-  const output = new Map();
-  const iter = map[Symbol.iterator]();
-  for (const [k, v] of iter) {
-    if (!num--) break;
-    output.set(k, v);
-  }
-  return [new Map(iter), output];
-}
 
 /**
  * Provide a resolved result to the given deferred object.

--- a/src/utils.js
+++ b/src/utils.js
@@ -12,9 +12,12 @@ export function extractFrom(map, num) {
   }
   const output = new Map();
   const iter = map[Symbol.iterator]();
-  for (const [k, v] of iter) {
-    if (!num--) break;
-    output.set(k, v);
+  if (num) {
+    for (const [k, v] of iter) {
+      output.set(k, v);
+      if (!--num) break;
+    }
   }
+
   return [new Map(iter), output];
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,20 @@
+/**
+ * Extract num entries from map and return them in a new Map.
+ *
+ * @param {Map} map The source map.
+ * @param {number} num The number of entries to extract.
+ * @return {[Map, Map]} The first value is a new Map containing the remaining entries from the
+ *   source map, and the second value is a new Map containing the extracted entries.
+ */
+export function extractFrom(map, num) {
+  if (!(num < map.size)) {
+    return [new Map(), new Map(map)];
+  }
+  const output = new Map();
+  const iter = map[Symbol.iterator]();
+  for (const [k, v] of iter) {
+    if (!num--) break;
+    output.set(k, v);
+  }
+  return [new Map(iter), output];
+}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -131,7 +131,7 @@ describe('adaptiveBatch', () => {
     let totalProcessed = 0;
     const getter = async (emailsIt) => {
       const emails = [...emailsIt];
-      await Promise.resolve();
+      await void Promise;
       totalProcessed += emails.length;
       return new Map(emails.map((email) => [email, email.toUpperCase()]));
     };

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,6 +1,12 @@
 import adaptiveBatch from '../src';
 import { defer } from 'promise-callbacks';
 
+function* range(num) {
+  for (let i = 0; i < num; ++i) {
+    yield num;
+  }
+}
+
 describe('adaptiveBatch', () => {
   it('should support multiple concurrent invocations', async () => {
     const d1 = defer(),
@@ -137,9 +143,7 @@ describe('adaptiveBatch', () => {
     });
 
     const numEmails = 500;
-    const emails = Array(numEmails)
-      .fill(null)
-      .map((_, idx) => `doot${idx}@noot.com`);
+    const emails = Array.from(range(numEmails)).map((_, idx) => `doot${idx}@noot.example.com`);
 
     const upperEmailPromises = emails.map(get).map((upperEmailPromise, idx) => {
       const email = emails[idx];

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,0 +1,32 @@
+import { extractFrom } from '../src/utils';
+
+describe('extractFrom', () => {
+  it('should function on empty maps', () => {
+    const map = new Map();
+    const [m1, m2] = extractFrom(map, 1);
+    expect(m1).not.toBe(map);
+    expect(m2).not.toBe(map);
+    expect(m1).not.toBe(m2);
+    expect(map).toHaveProperty('size', 0);
+    expect(m1).toEqual(map);
+    expect(m2).toEqual(map);
+  });
+
+  it('should drain the given map', () => {
+    const map = new Map([[1, 2]]);
+    const [m1, m2] = extractFrom(map, 3);
+    expect(map).toHaveProperty('size', 1);
+    expect(m1).toHaveProperty('size', 0);
+    expect(m2).toHaveProperty('size', 1);
+    expect(m2).toEqual(map);
+  });
+
+  it('should partially drain the given map', () => {
+    const map = new Map([[1, 2], [3, 4]]);
+    const [m1, m2] = extractFrom(map, 1);
+    expect(map).toHaveProperty('size', 2);
+    expect(m1).toHaveProperty('size', 1);
+    expect(m2).toHaveProperty('size', 1);
+    expect(new Map([...m1.entries(), ...m2.entries()])).toEqual(map);
+  });
+});


### PR DESCRIPTION
Adds a unit test that uses `adaptiveBatch` in a way similar to [how it's been used](https://github.com/mixmaxhq/compose/blob/b6e6f3801360711a2a1dfac01f1dd18bb035adf1/src/server/collections/sequences/index.js#L1436) to fetch Recommended Send Times in compose. Note that the test uses the [same configuration](https://github.com/mixmaxhq/compose/blob/b6e6f3801360711a2a1dfac01f1dd18bb035adf1/src/server/collections/sequences/utils/queryRST.js#L17) as compose.

The test currently fails, since it appears that a couple of the enqueued 'get's are never resolved. This is likely the root-cause of https://mixmaxhq.atlassian.net/browse/ST-1011.

